### PR TITLE
Remix v3 Future Flags

### DIFF
--- a/app/lib/utils/serialize.ts
+++ b/app/lib/utils/serialize.ts
@@ -1,0 +1,3 @@
+export const reviveDate = (inputDate: Date) => {
+  return new Date(inputDate)
+}

--- a/app/routes/api.$asset.entries.tsx
+++ b/app/routes/api.$asset.entries.tsx
@@ -1,4 +1,4 @@
-import {type LoaderFunctionArgs, type HeadersArgs, json} from '@remix-run/node'
+import {type LoaderFunctionArgs, type HeadersArgs} from '@remix-run/node'
 import {type Entry} from '@prisma/client'
 
 import {ensureUser} from '~/lib/utils/ensure-user'
@@ -33,7 +33,7 @@ export const loader = async ({request, params}: LoaderFunctionArgs) => {
       >`SELECT * FROM Entry INNER JOIN Value value ON fieldId = (SELECT nameFieldId from Asset WHERE id = ${params.asset}) AND entryId = entry.id WHERE assetId = (SELECT id from Asset WHERE id = ${params.asset}) AND deleted = false;`
   )
 
-  return json({asset, entries}, {headers: headers()})
+  return Response.json({asset, entries}, {headers: headers()})
 }
 
 export const headers = ({loaderHeaders}: HeadersArgs) => {

--- a/app/routes/api.assets.tsx
+++ b/app/routes/api.assets.tsx
@@ -1,4 +1,4 @@
-import {type LoaderFunctionArgs, type HeadersArgs, json} from '@remix-run/node'
+import {type LoaderFunctionArgs, type HeadersArgs} from '@remix-run/node'
 
 import {ensureUser} from '~/lib/utils/ensure-user'
 import {getPrisma} from '~/lib/prisma.server'
@@ -17,7 +17,7 @@ export const loader = async ({request}: LoaderFunctionArgs) => {
     prisma.asset.findMany({orderBy: {name: 'asc'}})
   )
 
-  return json({assets}, {headers: headers()})
+  return Response.json({assets}, {headers: headers()})
 }
 
 export const headers = ({loaderHeaders}: HeadersArgs) => {

--- a/app/routes/api.backup.tsx
+++ b/app/routes/api.backup.tsx
@@ -1,4 +1,4 @@
-import {type LoaderFunctionArgs, type HeadersArgs, json} from '@remix-run/node'
+import {type LoaderFunctionArgs, type HeadersArgs} from '@remix-run/node'
 
 import {ensureUser} from '~/lib/utils/ensure-user'
 import {createTimings} from '~/lib/utils/timings.server'
@@ -14,7 +14,7 @@ export const loader = async ({request}: LoaderFunctionArgs) => {
 
   await addJob('createBackup', {})
 
-  return json({user}, {headers: headers()})
+  return Response.json({user}, {headers: headers()})
 }
 
 export const headers = ({loaderHeaders}: HeadersArgs) => {

--- a/app/routes/api.fields.tsx
+++ b/app/routes/api.fields.tsx
@@ -1,4 +1,4 @@
-import {type LoaderFunctionArgs, type HeadersArgs, json} from '@remix-run/node'
+import {type LoaderFunctionArgs, type HeadersArgs} from '@remix-run/node'
 
 import {ensureUser} from '~/lib/utils/ensure-user'
 import {getPrisma} from '~/lib/prisma.server'
@@ -17,7 +17,7 @@ export const loader = async ({request}: LoaderFunctionArgs) => {
     prisma.field.findMany({orderBy: {name: 'asc'}})
   )
 
-  return json({fields}, {headers: headers()})
+  return Response.json({fields}, {headers: headers()})
 }
 
 export const headers = ({loaderHeaders}: HeadersArgs) => {

--- a/app/routes/api.me.tsx
+++ b/app/routes/api.me.tsx
@@ -1,4 +1,4 @@
-import {type LoaderFunctionArgs, type HeadersArgs, json} from '@remix-run/node'
+import {type LoaderFunctionArgs, type HeadersArgs} from '@remix-run/node'
 
 import {ensureUser} from '~/lib/utils/ensure-user'
 import {createTimings} from '~/lib/utils/timings.server'
@@ -10,7 +10,7 @@ export const loader = async ({request}: LoaderFunctionArgs) => {
     ensureUser(request, 'dashboard', {})
   )
 
-  return json({user}, {headers: headers()})
+  return Response.json({user}, {headers: headers()})
 }
 
 export const headers = ({loaderHeaders}: HeadersArgs) => {

--- a/app/routes/api.password.$password.get.tsx
+++ b/app/routes/api.password.$password.get.tsx
@@ -1,4 +1,4 @@
-import {type LoaderFunctionArgs, type HeadersArgs, json} from '@remix-run/node'
+import {type LoaderFunctionArgs, type HeadersArgs} from '@remix-run/node'
 
 import {ensureUser} from '~/lib/utils/ensure-user'
 import {getPrisma} from '~/lib/prisma.server'
@@ -24,7 +24,7 @@ export const loader = async ({request, params}: LoaderFunctionArgs) => {
   )
 
   if (userTotp.totpSecret === '') {
-    return json(
+    return Response.json(
       {password: "Can't fetch password without 2FA on your account"},
       {headers: headers()}
     )
@@ -52,7 +52,7 @@ export const loader = async ({request, params}: LoaderFunctionArgs) => {
     () => new Promise(resolve => resolve(decrypt(password.password)))
   )
 
-  return json({password: decryptedPassword})
+  return Response.json({password: decryptedPassword})
 }
 
 export const headers = ({loaderHeaders}: HeadersArgs) => {

--- a/app/routes/api.password.entries.tsx
+++ b/app/routes/api.password.entries.tsx
@@ -1,4 +1,4 @@
-import {type LoaderFunctionArgs, type HeadersArgs, json} from '@remix-run/node'
+import {type LoaderFunctionArgs, type HeadersArgs} from '@remix-run/node'
 
 import {ensureUser} from '~/lib/utils/ensure-user'
 import {getPrisma} from '~/lib/prisma.server'
@@ -21,7 +21,7 @@ export const loader = async ({request}: LoaderFunctionArgs) => {
     return {entryId: id, value: title}
   })
 
-  return json(
+  return Response.json(
     {
       asset: {id: 'passwords', slug: 'passwords', icon: '🔒'},
       entries

--- a/app/routes/api.password.tsx
+++ b/app/routes/api.password.tsx
@@ -1,4 +1,4 @@
-import {type LoaderFunctionArgs, type HeadersArgs, json} from '@remix-run/node'
+import {type LoaderFunctionArgs, type HeadersArgs} from '@remix-run/node'
 
 import {ensureUser} from '~/lib/utils/ensure-user'
 import {getPrisma} from '~/lib/prisma.server'
@@ -26,7 +26,7 @@ export const loader = async ({request, params}: LoaderFunctionArgs) => {
     })
   )
 
-  return json({asset, passwords}, {headers: headers()})
+  return Response.json({asset, passwords}, {headers: headers()})
 }
 
 export const headers = ({loaderHeaders}: HeadersArgs) => {

--- a/app/routes/api.pin.tsx
+++ b/app/routes/api.pin.tsx
@@ -1,4 +1,4 @@
-import {type ActionFunctionArgs, type HeadersArgs, json} from '@remix-run/node'
+import {type ActionFunctionArgs, type HeadersArgs} from '@remix-run/node'
 import {invariant} from '@arcath/utils'
 
 import {ensureUser} from '~/lib/utils/ensure-user'
@@ -32,7 +32,7 @@ export const action = async ({request}: ActionFunctionArgs) => {
       prisma.pin.deleteMany({where: {userId: user.id, target, targetId}})
     )
 
-    return json({pinId: '', result: 'remove'}, {headers: headers()})
+    return Response.json({pinId: '', result: 'remove'}, {headers: headers()})
   }
 
   const pin = await time('createPin', 'Create new pin', async () =>
@@ -41,7 +41,7 @@ export const action = async ({request}: ActionFunctionArgs) => {
     })
   )
 
-  return json({pinId: pin.id, result: 'add'}, {headers: headers()})
+  return Response.json({pinId: pin.id, result: 'add'}, {headers: headers()})
 }
 
 export const headers = ({actionHeaders}: HeadersArgs) => {

--- a/app/routes/api.process.$process.toggle.$nth.tsx
+++ b/app/routes/api.process.$process.toggle.$nth.tsx
@@ -1,4 +1,4 @@
-import {type LoaderFunctionArgs, type HeadersArgs, json} from '@remix-run/node'
+import {type LoaderFunctionArgs, type HeadersArgs} from '@remix-run/node'
 
 import {ensureUser} from '~/lib/utils/ensure-user'
 import {getPrisma} from '~/lib/prisma.server'
@@ -40,7 +40,7 @@ export const loader = async ({request, params}: LoaderFunctionArgs) => {
     data: {body: process.body}
   })
 
-  return json({body: process.body}, {headers: headers()})
+  return Response.json({body: process.body}, {headers: headers()})
 }
 
 export const headers = ({loaderHeaders}: HeadersArgs) => {

--- a/app/routes/api.session.$session.delete.tsx
+++ b/app/routes/api.session.$session.delete.tsx
@@ -1,4 +1,4 @@
-import {type ActionFunction, json} from '@remix-run/node'
+import {type ActionFunction} from '@remix-run/node'
 
 import {ensureUser} from '~/lib/utils/ensure-user'
 import {getPrisma} from '~/lib/prisma.server'
@@ -10,5 +10,5 @@ export const action: ActionFunction = async ({request, params}) => {
 
   await prisma.session.delete({where: {id: params.session}})
 
-  return json({})
+  return Response.json({})
 }

--- a/app/routes/app.$assetslug.$entry.$revision.tsx
+++ b/app/routes/app.$assetslug.$entry.$revision.tsx
@@ -1,4 +1,4 @@
-import {type LoaderFunctionArgs, type MetaFunction, json} from '@remix-run/node'
+import {type LoaderFunctionArgs, type MetaFunction} from '@remix-run/node'
 import {Link, useLoaderData} from '@remix-run/react'
 import {groupedBy} from '@arcath/utils'
 
@@ -76,7 +76,7 @@ export const loader = async ({request, params}: LoaderFunctionArgs) => {
     return ''
   }, '')
 
-  return json({user, entry, name, values, revisions, pastValues})
+  return {user, entry, name, values, revisions, pastValues}
 }
 
 export const meta: MetaFunction<typeof loader> = ({matches, data}) => {

--- a/app/routes/app.$assetslug.$entry._index.tsx
+++ b/app/routes/app.$assetslug.$entry._index.tsx
@@ -2,7 +2,7 @@ import {
   type LoaderFunctionArgs,
   type MetaFunction,
   type HeadersArgs,
-  json
+  data
 } from '@remix-run/node'
 import {Link, useLoaderData} from '@remix-run/react'
 import {
@@ -21,6 +21,7 @@ import {formatAsDateTime} from '~/lib/utils/format'
 import {can} from '~/lib/rbac.server'
 import {createTimings} from '~/lib/utils/timings.server'
 import {trackRecentItem} from '~/lib/utils/recent-item'
+import {reviveDate} from '~/lib/utils/serialize'
 
 export const loader = async ({request, params}: LoaderFunctionArgs) => {
   const {time, headers} = createTimings()
@@ -80,7 +81,7 @@ export const loader = async ({request, params}: LoaderFunctionArgs) => {
 
   const canEdit = await can(user.role, 'entry:edit', {user, entryId: entry.id})
 
-  return json(
+  return data(
     {
       user,
       entry,
@@ -196,7 +197,8 @@ const AssetEntry = () => {
                 to={`/app/${entry.asset.slug}/${entry.id}/${id}`}
                 className="text-sm text-gray-400"
               >
-                {formatAsDateTime(createdAt)} - {userName}
+                {formatAsDateTime(reviveDate(createdAt).toISOString())} -{' '}
+                {userName}
               </Link>
             </div>
           )

--- a/app/routes/app.$assetslug.$entry.delete.tsx
+++ b/app/routes/app.$assetslug.$entry.delete.tsx
@@ -2,7 +2,6 @@ import {
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
-  json,
   redirect
 } from '@remix-run/node'
 import {invariant} from '@arcath/utils'
@@ -34,7 +33,7 @@ export const loader = async ({request, params}: LoaderFunctionArgs) => {
     return ''
   }, '')
 
-  return json({user, entry, name})
+  return {user, entry, name}
 }
 
 export const action = async ({request, params}: ActionFunctionArgs) => {
@@ -68,7 +67,7 @@ export const action = async ({request, params}: ActionFunctionArgs) => {
     return redirect(`/app/${entry.asset.slug}`)
   }
 
-  return json({error: 'Name does not match'})
+  return {error: 'Name does not match'}
 }
 
 export const meta: MetaFunction<typeof loader> = ({matches, data}) => {

--- a/app/routes/app.$assetslug.$entry.edit.tsx
+++ b/app/routes/app.$assetslug.$entry.edit.tsx
@@ -2,7 +2,6 @@ import {
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
-  json,
   redirect,
   unstable_parseMultipartFormData
 } from '@remix-run/node'
@@ -52,7 +51,7 @@ export const loader = async ({request, params}: LoaderFunctionArgs) => {
 
   const acls = await prisma.aCL.findMany({orderBy: {name: 'asc'}})
 
-  return json({user, entry, name, acls})
+  return {user, entry, name, acls}
 }
 
 export const action = async ({request, params}: ActionFunctionArgs) => {
@@ -160,7 +159,7 @@ export const action = async ({request, params}: ActionFunctionArgs) => {
   const flags = results.filter(v => v !== true)
 
   if (flags.length > 0) {
-    return json({errors: flags})
+    return {errors: flags}
   }
 
   return redirect(`/app/${params.assetslug}/${params.entry}`)

--- a/app/routes/app.$assetslug.$entry.link-password.tsx
+++ b/app/routes/app.$assetslug.$entry.link-password.tsx
@@ -2,7 +2,6 @@ import {
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
-  json,
   redirect
 } from '@remix-run/node'
 import {asyncForEach, diffArray, invariant} from '@arcath/utils'
@@ -29,7 +28,7 @@ export const loader = async ({request, params}: LoaderFunctionArgs) => {
     }
   })
 
-  return json({user, entry})
+  return {user, entry}
 }
 
 export const action = async ({request, params}: ActionFunctionArgs) => {
@@ -56,14 +55,6 @@ export const action = async ({request, params}: ActionFunctionArgs) => {
   const currentPasswordIds = links.map(({passwordId}) => passwordId)
 
   const {additional, missing} = diffArray(currentPasswordIds, newPasswordIds)
-
-  console.dir([
-    passwordsString,
-    newPasswordIds,
-    currentPasswordIds,
-    additional,
-    missing
-  ])
 
   await asyncForEach(additional, async passwordId => {
     await prisma.entryPassword.create({data: {passwordId, entryId}})

--- a/app/routes/app.$assetslug._index.tsx
+++ b/app/routes/app.$assetslug._index.tsx
@@ -2,7 +2,7 @@ import {
   type LoaderFunctionArgs,
   type MetaFunction,
   type HeadersArgs,
-  json
+  data
 } from '@remix-run/node'
 import {indexedBy} from '@arcath/utils'
 
@@ -86,7 +86,7 @@ export const loader = async ({request, params}: LoaderFunctionArgs) => {
     )`
   )
 
-  return json(
+  return data(
     {user, asset, entries, values: indexedBy('lookup', extraValues)},
     {headers: headers({'Set-Cookie': user.setCookie})}
   )

--- a/app/routes/app.$assetslug.add.tsx
+++ b/app/routes/app.$assetslug.add.tsx
@@ -2,7 +2,6 @@ import {
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
-  json,
   redirect,
   unstable_parseMultipartFormData
 } from '@remix-run/node'
@@ -30,7 +29,7 @@ export const loader = async ({request, params}: LoaderFunctionArgs) => {
     include: {assetFields: {include: {field: true}, orderBy: {order: 'asc'}}}
   })
 
-  return json({user, asset})
+  return {user, asset}
 }
 
 export const action = async ({request, params}: ActionFunctionArgs) => {
@@ -112,7 +111,7 @@ export const action = async ({request, params}: ActionFunctionArgs) => {
     await prisma.value.deleteMany({where: {entryId: entry.id}})
     await prisma.entry.delete({where: {id: entry.id}})
 
-    return json({errors: flags})
+    return {errors: flags}
   }
 
   return redirect(`/app/${params.assetslug}/${entry.id}`)

--- a/app/routes/app.$assetslug.import.tsx
+++ b/app/routes/app.$assetslug.import.tsx
@@ -1,8 +1,7 @@
 import {
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
-  type MetaFunction,
-  json
+  type MetaFunction
 } from '@remix-run/node'
 import {useLoaderData} from '@remix-run/react'
 import {asyncForEach, asyncMap} from '@arcath/utils'
@@ -27,7 +26,7 @@ export const loader = async ({request, params}: LoaderFunctionArgs) => {
     include: {assetFields: {include: {field: true}, orderBy: {order: 'asc'}}}
   })
 
-  return json({user, asset})
+  return {user, asset}
 }
 
 export const action = async ({request, params}: ActionFunctionArgs) => {
@@ -75,7 +74,7 @@ export const action = async ({request, params}: ActionFunctionArgs) => {
     }
   )
 
-  return json({status: 200})
+  return {status: 200}
 }
 
 export const meta: MetaFunction<typeof loader> = ({matches, data}) => {

--- a/app/routes/app.$assetslug.tsx
+++ b/app/routes/app.$assetslug.tsx
@@ -1,4 +1,4 @@
-import {type LoaderFunctionArgs, json} from '@remix-run/node'
+import {type LoaderFunctionArgs} from '@remix-run/node'
 import {Outlet, useLoaderData, useMatches} from '@remix-run/react'
 import {invariant} from '@arcath/utils'
 
@@ -19,7 +19,7 @@ export const loader = async ({request, params}: LoaderFunctionArgs) => {
     include: {assetFields: {include: {field: true}}}
   })
 
-  return json({user, asset})
+  return {user, asset}
 }
 
 const Asset = () => {

--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -2,7 +2,7 @@ import {
   type LoaderFunctionArgs,
   type MetaFunction,
   type HeadersArgs,
-  json
+  data
 } from '@remix-run/node'
 import {useLoaderData} from '@remix-run/react'
 import {asyncMap} from '@arcath/utils'
@@ -41,7 +41,7 @@ export const loader = async ({request, params}: LoaderFunctionArgs) => {
     })
   )
 
-  return json({user, boxes: boxesWithData}, {headers: headers()})
+  return data({user, boxes: boxesWithData}, {headers: headers()})
 }
 
 export const meta: MetaFunction = ({matches}) => {

--- a/app/routes/app.acl-manager.$acl.tsx
+++ b/app/routes/app.acl-manager.$acl.tsx
@@ -1,7 +1,6 @@
 import {
   type LoaderFunctionArgs,
   type MetaFunction,
-  json,
   type ActionFunction,
   redirect
 } from '@remix-run/node'
@@ -31,7 +30,7 @@ export const loader = async ({request, params}: LoaderFunctionArgs) => {
     select: {id: true, name: true}
   })
 
-  return json({user, acl, users})
+  return {user, acl, users}
 }
 
 export const action: ActionFunction = async ({request, params}) => {

--- a/app/routes/app.acl-manager._index.tsx
+++ b/app/routes/app.acl-manager._index.tsx
@@ -1,4 +1,4 @@
-import {type LoaderFunctionArgs, type MetaFunction, json} from '@remix-run/node'
+import {type LoaderFunctionArgs, type MetaFunction} from '@remix-run/node'
 import {useLoaderData, Link} from '@remix-run/react'
 import {pageTitle} from '~/lib/utils/page-title'
 
@@ -12,7 +12,7 @@ export const loader = async ({request}: LoaderFunctionArgs) => {
 
   const acls = await prisma.aCL.findMany({orderBy: {name: 'asc'}})
 
-  return json({user, acls})
+  return {user, acls}
 }
 
 export const meta: MetaFunction = ({matches}) => {

--- a/app/routes/app.acl-manager.add.tsx
+++ b/app/routes/app.acl-manager.add.tsx
@@ -2,7 +2,6 @@ import {
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
-  json,
   redirect
 } from '@remix-run/node'
 import {invariant} from '@arcath/utils'
@@ -16,7 +15,7 @@ import {pageTitle} from '~/lib/utils/page-title'
 export const loader = async ({request}: LoaderFunctionArgs) => {
   const user = await ensureUser(request, 'asset-manager:add', {})
 
-  return json({user})
+  return {user}
 }
 
 export const action = async ({request}: ActionFunctionArgs) => {

--- a/app/routes/app.asset-manager.$asset.$assetfield.tsx
+++ b/app/routes/app.asset-manager.$asset.$assetfield.tsx
@@ -2,7 +2,6 @@ import {
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
-  json,
   redirect
 } from '@remix-run/node'
 import {useLoaderData} from '@remix-run/react'
@@ -31,7 +30,7 @@ export const loader = async ({request, params}: LoaderFunctionArgs) => {
     include: {field: true}
   })
 
-  return json({user, assetField})
+  return {user, assetField}
 }
 
 export const action = async ({request, params}: ActionFunctionArgs) => {

--- a/app/routes/app.asset-manager.$asset.add_.$field.tsx
+++ b/app/routes/app.asset-manager.$asset.add_.$field.tsx
@@ -1,7 +1,6 @@
 import {
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
-  json,
   redirect
 } from '@remix-run/node'
 import {useLoaderData} from '@remix-run/react'
@@ -21,7 +20,7 @@ export const loader = async ({request, params}: LoaderFunctionArgs) => {
 
   const field = await prisma.field.findFirstOrThrow({where: {id: params.field}})
 
-  return json({user, field})
+  return {user, field}
 }
 
 export const action = async ({request, params}: ActionFunctionArgs) => {

--- a/app/routes/app.asset-manager.$asset.edit.tsx
+++ b/app/routes/app.asset-manager.$asset.edit.tsx
@@ -1,7 +1,6 @@
 import {
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
-  json,
   redirect
 } from '@remix-run/node'
 import {useLoaderData} from '@remix-run/react'
@@ -31,7 +30,7 @@ export const loader = async ({request, params}: LoaderFunctionArgs) => {
 
   const acls = await prisma.aCL.findMany({orderBy: {name: 'asc'}})
 
-  return json({user, asset, acls})
+  return {user, asset, acls}
 }
 
 export const action = async ({request, params}: ActionFunctionArgs) => {

--- a/app/routes/app.asset-manager.$asset.tsx
+++ b/app/routes/app.asset-manager.$asset.tsx
@@ -1,4 +1,4 @@
-import {type LoaderFunctionArgs, type MetaFunction, json} from '@remix-run/node'
+import {type LoaderFunctionArgs, type MetaFunction} from '@remix-run/node'
 import {Outlet, useLoaderData, Link} from '@remix-run/react'
 
 import {ensureUser} from '~/lib/utils/ensure-user'
@@ -27,7 +27,7 @@ export const loader = async ({request, params}: LoaderFunctionArgs) => {
     where: {id: {notIn: fieldIds}}
   })
 
-  return json({user, asset, fields})
+  return {user, asset, fields}
 }
 
 export const meta: MetaFunction<typeof loader> = ({matches, data}) => {

--- a/app/routes/app.asset-manager._index.tsx
+++ b/app/routes/app.asset-manager._index.tsx
@@ -1,4 +1,4 @@
-import {type LoaderFunctionArgs, type MetaFunction, json} from '@remix-run/node'
+import {type LoaderFunctionArgs, type MetaFunction} from '@remix-run/node'
 import {useLoaderData, Link} from '@remix-run/react'
 import {pageTitle} from '~/lib/utils/page-title'
 
@@ -12,7 +12,7 @@ export const loader = async ({request}: LoaderFunctionArgs) => {
 
   const assets = await prisma.asset.findMany({orderBy: {name: 'asc'}})
 
-  return json({user, assets})
+  return {user, assets}
 }
 
 export const meta: MetaFunction = ({matches}) => {

--- a/app/routes/app.asset-manager.add.tsx
+++ b/app/routes/app.asset-manager.add.tsx
@@ -2,7 +2,6 @@ import {
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
-  json,
   redirect
 } from '@remix-run/node'
 import {invariant} from '@arcath/utils'
@@ -21,7 +20,7 @@ export const loader = async ({request}: LoaderFunctionArgs) => {
 
   const acls = await prisma.aCL.findMany({orderBy: {name: 'asc'}})
 
-  return json({user, acls})
+  return {user, acls}
 }
 
 export const action = async ({request}: ActionFunctionArgs) => {

--- a/app/routes/app.dashboard.tsx
+++ b/app/routes/app.dashboard.tsx
@@ -3,7 +3,7 @@ import {
   type ActionFunctionArgs,
   type MetaFunction,
   type HeadersArgs,
-  json,
+  data,
   redirect
 } from '@remix-run/node'
 import {useLoaderData} from '@remix-run/react'
@@ -36,7 +36,7 @@ export const loader = async ({request}: LoaderFunctionArgs) => {
     })
   )
 
-  return json({user, boxes}, {headers: headers()})
+  return data({user, boxes}, {headers: headers()})
 }
 
 export const action = async ({request}: ActionFunctionArgs) => {
@@ -58,8 +58,6 @@ export const action = async ({request}: ActionFunctionArgs) => {
 
     invariant(meta)
     invariant(boxType)
-
-    console.dir(meta, boxType)
 
     if (id.substring(0, 3) === 'new') {
       await prisma.dashboardBox.create({data: {order: i, boxType, meta}})

--- a/app/routes/app.documents.$document.$revision.tsx
+++ b/app/routes/app.documents.$document.$revision.tsx
@@ -1,4 +1,4 @@
-import {type LoaderFunctionArgs, type MetaFunction, json} from '@remix-run/node'
+import {type LoaderFunctionArgs, type MetaFunction} from '@remix-run/node'
 import {useLoaderData, Link} from '@remix-run/react'
 
 import {ensureUser} from '~/lib/utils/ensure-user'
@@ -8,6 +8,7 @@ import {MDXComponent} from '~/lib/mdx'
 import {pageTitle} from '~/lib/utils/page-title'
 import {formatAsDateTime} from '~/lib/utils/format'
 import {LinkButton} from '~/lib/components/button'
+import {reviveDate} from '~/lib/utils/serialize'
 
 export const loader = async ({request, params}: LoaderFunctionArgs) => {
   const user = await ensureUser(request, 'document:view', {
@@ -29,7 +30,7 @@ export const loader = async ({request, params}: LoaderFunctionArgs) => {
 
   const code = await buildMDXBundle(revision.previousBody)
 
-  return json({user, document, code, title: revision.previousTitle})
+  return {user, document, code, title: revision.previousTitle}
 }
 
 export const meta: MetaFunction<typeof loader> = ({data, matches}) => {
@@ -64,7 +65,8 @@ const DocumentViewRevision = () => {
                 to={`/app/documents/${document.id}/${id}`}
                 className="text-sm text-gray-400"
               >
-                {formatAsDateTime(createdAt)} - {editedBy.name}
+                {formatAsDateTime(reviveDate(createdAt).toISOString())} -{' '}
+                {editedBy.name}
               </Link>
             </div>
           )

--- a/app/routes/app.documents.$document._index.tsx
+++ b/app/routes/app.documents.$document._index.tsx
@@ -1,4 +1,4 @@
-import {type LoaderFunctionArgs, type MetaFunction, json} from '@remix-run/node'
+import {type LoaderFunctionArgs, type MetaFunction} from '@remix-run/node'
 import {useLoaderData, Link} from '@remix-run/react'
 
 import {ensureUser} from '~/lib/utils/ensure-user'
@@ -10,6 +10,7 @@ import {formatAsDateTime} from '~/lib/utils/format'
 import {trackRecentItem} from '~/lib/utils/recent-item'
 import {LinkButton} from '~/lib/components/button'
 import {can} from '~/lib/rbac.server'
+import {reviveDate} from '~/lib/utils/serialize'
 
 import {type Attachment} from './app.documents.$document.attach'
 
@@ -38,13 +39,13 @@ export const loader = async ({request, params}: LoaderFunctionArgs) => {
 
   const attachments = JSON.parse(document.attachments) as Array<Attachment>
 
-  return json({
+  return {
     user,
     document,
     code,
     canWrite,
     attachments: attachments.filter(v => v !== null)
-  })
+  }
 }
 
 export const meta: MetaFunction<typeof loader> = ({matches, data}) => {
@@ -98,7 +99,8 @@ const DocumentView = () => {
                 to={`/app/documents/${document.id}/${id}`}
                 className="text-sm text-gray-400"
               >
-                {formatAsDateTime(createdAt)} - {editedBy.name}
+                {formatAsDateTime(reviveDate(createdAt).toISOString())} -{' '}
+                {editedBy.name}
               </Link>
             </div>
           )

--- a/app/routes/app.documents.$document.attach.tsx
+++ b/app/routes/app.documents.$document.attach.tsx
@@ -1,7 +1,6 @@
 import {
   type LoaderFunctionArgs,
   type MetaFunction,
-  json,
   type ActionFunctionArgs,
   redirect,
   unstable_parseMultipartFormData
@@ -53,11 +52,11 @@ export const loader = async ({request, params}: LoaderFunctionArgs) => {
     })
   }
 
-  return json({
+  return {
     user,
     document,
     attachments: attachments.filter(v => v !== null)
-  })
+  }
 }
 
 export const meta: MetaFunction<typeof loader> = ({data, matches}) => {

--- a/app/routes/app.documents.$document.edit.tsx
+++ b/app/routes/app.documents.$document.edit.tsx
@@ -2,7 +2,6 @@ import {
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
-  json,
   redirect
 } from '@remix-run/node'
 import {useLoaderData} from '@remix-run/react'
@@ -33,7 +32,7 @@ export const loader = async ({request, params}: LoaderFunctionArgs) => {
 
   const acls = await prisma.aCL.findMany({orderBy: {name: 'asc'}})
 
-  return json({user, document, acls})
+  return {user, document, acls}
 }
 
 export const action = async ({request, params}: ActionFunctionArgs) => {

--- a/app/routes/app.documents._index.tsx
+++ b/app/routes/app.documents._index.tsx
@@ -1,4 +1,4 @@
-import {type LoaderFunctionArgs, type MetaFunction, json} from '@remix-run/node'
+import {type LoaderFunctionArgs, type MetaFunction} from '@remix-run/node'
 import {useLoaderData, Link} from '@remix-run/react'
 import {getDocuments} from '@prisma/client/sql'
 
@@ -6,6 +6,7 @@ import {ensureUser} from '~/lib/utils/ensure-user'
 import {getPrisma} from '~/lib/prisma.server'
 import {formatAsDate} from '~/lib/utils/format'
 import {pageTitle} from '~/lib/utils/page-title'
+import {reviveDate} from '~/lib/utils/serialize'
 
 export const loader = async ({request}: LoaderFunctionArgs) => {
   const user = await ensureUser(request, 'document:list', {})
@@ -16,7 +17,7 @@ export const loader = async ({request}: LoaderFunctionArgs) => {
     getDocuments(user.role, user.id)
   )
 
-  return json({user, documents})
+  return {user, documents}
 }
 
 export const meta: MetaFunction = ({matches}) => {
@@ -44,7 +45,7 @@ const DocumentsList = () => {
                     {title}
                   </Link>
                 </td>
-                <td>{formatAsDate(updatedAt)}</td>
+                <td>{formatAsDate(reviveDate(updatedAt).toISOString())}</td>
               </tr>
             )
           })}

--- a/app/routes/app.documents.add.tsx
+++ b/app/routes/app.documents.add.tsx
@@ -2,7 +2,6 @@ import {
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
-  json,
   redirect
 } from '@remix-run/node'
 import {useLoaderData} from '@remix-run/react'
@@ -30,7 +29,7 @@ export const loader = async ({request}: LoaderFunctionArgs) => {
 
   const defaultAclId = await getDefaultACLID()
 
-  return json({user, acls, defaultAclId})
+  return {user, acls, defaultAclId}
 }
 
 export const action = async ({request}: ActionFunctionArgs) => {

--- a/app/routes/app.field-manager.$field.tsx
+++ b/app/routes/app.field-manager.$field.tsx
@@ -2,7 +2,6 @@ import {
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
-  json,
   redirect
 } from '@remix-run/node'
 import {useLoaderData} from '@remix-run/react'
@@ -27,7 +26,7 @@ export const loader = async ({request, params}: LoaderFunctionArgs) => {
     where: {id: params.field}
   })
 
-  return json({user, field})
+  return {user, field}
 }
 
 export const action = async ({request, params}: ActionFunctionArgs) => {

--- a/app/routes/app.field-manager._index.tsx
+++ b/app/routes/app.field-manager._index.tsx
@@ -1,4 +1,4 @@
-import {type LoaderFunctionArgs, type MetaFunction, json} from '@remix-run/node'
+import {type LoaderFunctionArgs, type MetaFunction} from '@remix-run/node'
 import {useLoaderData, Link} from '@remix-run/react'
 
 import {ensureUser} from '~/lib/utils/ensure-user'
@@ -12,7 +12,7 @@ export const loader = async ({request}: LoaderFunctionArgs) => {
 
   const fields = await prisma.field.findMany({orderBy: {name: 'asc'}})
 
-  return json({user, fields})
+  return {user, fields}
 }
 
 export const meta: MetaFunction = ({matches}) => {

--- a/app/routes/app.field-manager.add.tsx
+++ b/app/routes/app.field-manager.add.tsx
@@ -2,7 +2,6 @@ import {
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
-  json,
   redirect
 } from '@remix-run/node'
 import {invariant} from '@arcath/utils'
@@ -19,7 +18,7 @@ import {FIELD_HANDLERS} from '~/lib/fields/field.server'
 export const loader = async ({request}: LoaderFunctionArgs) => {
   const user = await ensureUser(request, 'field-manager:add', {})
 
-  return json({user})
+  return {user}
 }
 
 export const action = async ({request}: ActionFunctionArgs) => {

--- a/app/routes/app.passwords.$password.$revision.tsx
+++ b/app/routes/app.passwords.$password.$revision.tsx
@@ -1,4 +1,4 @@
-import {type LoaderFunctionArgs, type MetaFunction, json} from '@remix-run/node'
+import {type LoaderFunctionArgs, type MetaFunction} from '@remix-run/node'
 import {useLoaderData} from '@remix-run/react'
 
 import {ensureUser} from '~/lib/utils/ensure-user'
@@ -8,6 +8,7 @@ import {MDXComponent} from '~/lib/mdx'
 import {formatAsDateTime} from '~/lib/utils/format'
 import {pageTitle} from '~/lib/utils/page-title'
 import {getCryptoSuite} from '~/lib/crypto.server'
+import {reviveDate} from '~/lib/utils/serialize'
 
 export const loader = async ({request, params}: LoaderFunctionArgs) => {
   const user = await ensureUser(request, 'password:view', {
@@ -37,13 +38,13 @@ export const loader = async ({request, params}: LoaderFunctionArgs) => {
 
   const code = await buildMDXBundle(revision.previousNotes)
 
-  return json({
+  return {
     user,
     password,
     code,
     revision,
     previousPassword: decrypt(revision.previousPassword)
-  })
+  }
 }
 
 export const meta: MetaFunction<typeof loader> = ({matches, data}) => {
@@ -83,7 +84,7 @@ const AssetManagerAsset = () => {
               {user.name}
               <br />
               <span className="text-gray-400">
-                {formatAsDateTime(createdAt)}
+                {formatAsDateTime(reviveDate(createdAt).toISOString())}
               </span>
             </div>
           )

--- a/app/routes/app.passwords.$password._index.tsx
+++ b/app/routes/app.passwords.$password._index.tsx
@@ -1,4 +1,4 @@
-import {type LoaderFunctionArgs, type MetaFunction, json} from '@remix-run/node'
+import {type LoaderFunctionArgs, type MetaFunction} from '@remix-run/node'
 import {useLoaderData, Link} from '@remix-run/react'
 import {useState} from 'react'
 import {useQuery} from '@tanstack/react-query'
@@ -11,6 +11,7 @@ import {formatAsDateTime} from '~/lib/utils/format'
 import {pageTitle} from '~/lib/utils/page-title'
 import {useNotify} from '~/lib/hooks/use-notify'
 import {trackRecentItem} from '~/lib/utils/recent-item'
+import {reviveDate} from '~/lib/utils/serialize'
 
 export const loader = async ({request, params}: LoaderFunctionArgs) => {
   const user = await ensureUser(request, 'password:view', {
@@ -37,7 +38,7 @@ export const loader = async ({request, params}: LoaderFunctionArgs) => {
 
   const code = await buildMDXBundle(password.notes)
 
-  return json({user, password, code})
+  return {user, password, code}
 }
 
 export const meta: MetaFunction<typeof loader> = ({data, matches}) => {
@@ -116,7 +117,7 @@ const AssetManagerAsset = () => {
               {user.name}
               <br />
               <span className="text-gray-400">
-                {formatAsDateTime(createdAt)}
+                {formatAsDateTime(reviveDate(createdAt).toISOString())}
               </span>
             </div>
           )
@@ -131,7 +132,8 @@ const AssetManagerAsset = () => {
                 to={`/app/passwords/${password.id}/${id}`}
                 className="text-sm text-gray-400"
               >
-                {formatAsDateTime(createdAt)} - {editedBy.name}
+                {formatAsDateTime(reviveDate(createdAt).toISOString())} -{' '}
+                {editedBy.name}
               </Link>
             </div>
           )

--- a/app/routes/app.passwords.$password.edit.tsx
+++ b/app/routes/app.passwords.$password.edit.tsx
@@ -2,7 +2,6 @@ import {
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
-  json,
   redirect
 } from '@remix-run/node'
 import {useLoaderData} from '@remix-run/react'
@@ -36,7 +35,7 @@ export const loader = async ({request, params}: LoaderFunctionArgs) => {
 
   const acls = await prisma.aCL.findMany({orderBy: {name: 'asc'}})
 
-  return json({user, password, decrypted: decrypt(password.password), acls})
+  return {user, password, decrypted: decrypt(password.password), acls}
 }
 
 export const action = async ({request, params}: ActionFunctionArgs) => {

--- a/app/routes/app.passwords._index.tsx
+++ b/app/routes/app.passwords._index.tsx
@@ -1,4 +1,4 @@
-import {type LoaderFunctionArgs, type MetaFunction, json} from '@remix-run/node'
+import {type LoaderFunctionArgs, type MetaFunction} from '@remix-run/node'
 import {useLoaderData, Link} from '@remix-run/react'
 import {getPasswords} from '@prisma/client/sql'
 
@@ -15,7 +15,7 @@ export const loader = async ({request}: LoaderFunctionArgs) => {
     getPasswords(user.role, user.id)
   )
 
-  return json({user, passwords})
+  return {user, passwords}
 }
 
 export const meta: MetaFunction = ({matches}) => {

--- a/app/routes/app.passwords.add.tsx
+++ b/app/routes/app.passwords.add.tsx
@@ -2,7 +2,6 @@ import {
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
-  json,
   redirect
 } from '@remix-run/node'
 import {useLoaderData} from '@remix-run/react'
@@ -32,7 +31,7 @@ export const loader = async ({request}: LoaderFunctionArgs) => {
 
   const defaultAclId = await getDefaultACLID()
 
-  return json({user, acls, defaultAclId})
+  return {user, acls, defaultAclId}
 }
 
 export const action = async ({request}: ActionFunctionArgs) => {

--- a/app/routes/app.process.$process._index.tsx
+++ b/app/routes/app.process.$process._index.tsx
@@ -1,4 +1,4 @@
-import {type LoaderFunctionArgs, type MetaFunction, json} from '@remix-run/node'
+import {type LoaderFunctionArgs, type MetaFunction} from '@remix-run/node'
 import {useLoaderData} from '@remix-run/react'
 import {useEffect} from 'react'
 
@@ -24,7 +24,7 @@ export const loader = async ({request, params}: LoaderFunctionArgs) => {
 
   const code = await buildMDXBundle(process.body)
 
-  return json({user, process, code})
+  return {user, process, code}
 }
 
 export const meta: MetaFunction<typeof loader> = ({data, matches}) => {

--- a/app/routes/app.process.$process.edit.tsx
+++ b/app/routes/app.process.$process.edit.tsx
@@ -2,7 +2,6 @@ import {
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
-  json,
   redirect
 } from '@remix-run/node'
 import {useLoaderData} from '@remix-run/react'
@@ -25,7 +24,7 @@ export const loader = async ({request, params}: LoaderFunctionArgs) => {
     where: {id: params.process}
   })
 
-  return json({user, process})
+  return {user, process}
 }
 
 export const action = async ({request, params}: ActionFunctionArgs) => {

--- a/app/routes/app.process._index.tsx
+++ b/app/routes/app.process._index.tsx
@@ -1,4 +1,4 @@
-import {type LoaderFunctionArgs, type MetaFunction, json} from '@remix-run/node'
+import {type LoaderFunctionArgs, type MetaFunction} from '@remix-run/node'
 import {useLoaderData, Link} from '@remix-run/react'
 import {getProcesses, getProcessesFromDocuments} from '@prisma/client/sql'
 
@@ -7,6 +7,7 @@ import {getPrisma} from '~/lib/prisma.server'
 import {formatAsDate} from '~/lib/utils/format'
 import {pageTitle} from '~/lib/utils/page-title'
 import {AButton} from '~/lib/components/button'
+import {reviveDate} from '~/lib/utils/serialize'
 
 export const loader = async ({request}: LoaderFunctionArgs) => {
   const user = await ensureUser(request, 'process:list', {})
@@ -21,7 +22,7 @@ export const loader = async ({request}: LoaderFunctionArgs) => {
     getProcessesFromDocuments(user.role, user.id)
   )
 
-  return json({user, processes, documents})
+  return {user, processes, documents}
 }
 
 export const meta: MetaFunction = ({matches}) => {
@@ -50,7 +51,7 @@ const ProcessList = () => {
                     {title}
                   </Link>
                 </td>
-                <td>{formatAsDate(updatedAt)}</td>
+                <td>{formatAsDate(reviveDate(updatedAt).toISOString())}</td>
                 <td>{complete ? 'Yes' : 'No'}</td>
               </tr>
             )

--- a/app/routes/app.search.tsx
+++ b/app/routes/app.search.tsx
@@ -1,8 +1,7 @@
 import {
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
-  type MetaFunction,
-  json
+  type MetaFunction
 } from '@remix-run/node'
 import {Link, useActionData} from '@remix-run/react'
 import {invariant} from '@arcath/utils'
@@ -21,7 +20,7 @@ import {pageTitle} from '~/lib/utils/page-title'
 export const loader = async ({request}: LoaderFunctionArgs) => {
   const user = await ensureUser(request, 'search', {})
 
-  return json({user})
+  return {user}
 }
 
 export const action = async ({request}: ActionFunctionArgs) => {
@@ -53,7 +52,7 @@ export const action = async ({request}: ActionFunctionArgs) => {
     ...documentResults
   ].sort((a, b) => (a.label ?? '').localeCompare(b.label ?? ''))
 
-  return json({results, query})
+  return {results, query}
 }
 
 export const meta: MetaFunction = ({matches}) => {

--- a/app/routes/app.system.tsx
+++ b/app/routes/app.system.tsx
@@ -2,7 +2,6 @@ import {
   type MetaFunction,
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
-  json,
   redirect,
   unstable_parseMultipartFormData
 } from '@remix-run/node'
@@ -27,7 +26,7 @@ export const loader = async ({request}: LoaderFunctionArgs) => {
 
   const settings = await getSettings(['site-name', 'site-color'])
 
-  return json({user, files, settings})
+  return {user, files, settings}
 }
 
 export const action = async ({request}: ActionFunctionArgs) => {

--- a/app/routes/app.tsx
+++ b/app/routes/app.tsx
@@ -1,4 +1,4 @@
-import {type LoaderFunctionArgs, json} from '@remix-run/node'
+import {type LoaderFunctionArgs} from '@remix-run/node'
 import {
   Outlet,
   useRouteError,
@@ -49,7 +49,7 @@ export const loader = async ({request}: LoaderFunctionArgs) => {
 
   const settings = await getSettings(['site-name', 'site-color', 'site-icon'])
 
-  return json({user, assets, cans, settings})
+  return {user, assets, cans, settings}
 }
 
 export type AppLoader = {user: {name: string; id: string}}

--- a/app/routes/app.user-manager.$user.tsx
+++ b/app/routes/app.user-manager.$user.tsx
@@ -2,7 +2,6 @@ import {
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
-  json,
   redirect
 } from '@remix-run/node'
 import {useLoaderData} from '@remix-run/react'
@@ -24,7 +23,7 @@ export const loader = async ({request, params}: LoaderFunctionArgs) => {
 
   const user = await prisma.user.findFirstOrThrow({where: {id: params.user}})
 
-  return json({currentUser, user})
+  return {currentUser, user}
 }
 
 export const action = async ({request, params}: ActionFunctionArgs) => {

--- a/app/routes/app.user-manager._index.tsx
+++ b/app/routes/app.user-manager._index.tsx
@@ -1,4 +1,4 @@
-import {type LoaderFunctionArgs, type MetaFunction, json} from '@remix-run/node'
+import {type LoaderFunctionArgs, type MetaFunction} from '@remix-run/node'
 import {useLoaderData, Link} from '@remix-run/react'
 
 import {ensureUser} from '~/lib/utils/ensure-user'
@@ -15,7 +15,7 @@ export const loader = async ({request}: LoaderFunctionArgs) => {
     orderBy: {name: 'asc'}
   })
 
-  return json({user, users})
+  return {user, users}
 }
 
 export const meta: MetaFunction = ({matches}) => {

--- a/app/routes/app.user-manager.add.tsx
+++ b/app/routes/app.user-manager.add.tsx
@@ -2,7 +2,6 @@ import {
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
-  json,
   redirect
 } from '@remix-run/node'
 import {invariant} from '@arcath/utils'
@@ -19,7 +18,7 @@ export const loader = async ({request, params}: LoaderFunctionArgs) => {
     userId: params.user
   })
 
-  return json({currentUser})
+  return {currentUser}
 }
 
 export const action = async ({request, params}: ActionFunctionArgs) => {

--- a/app/routes/app.user.totp.tsx
+++ b/app/routes/app.user.totp.tsx
@@ -1,8 +1,7 @@
 import {
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
-  type MetaFunction,
-  json
+  type MetaFunction
 } from '@remix-run/node'
 import {useLoaderData, useActionData} from '@remix-run/react'
 import {invariant, omit} from '@arcath/utils'
@@ -44,14 +43,14 @@ export const loader = async ({request}: LoaderFunctionArgs) => {
   })
   const dataURL = await toDataURL(otpUri)
 
-  return json({
+  return {
     currentUser,
     totp,
     state,
     genTotp: omit(genTotp, ['otp']),
     otpUri,
     dataURL
-  })
+  }
 }
 
 export const action = async ({request}: ActionFunctionArgs) => {
@@ -82,7 +81,7 @@ export const action = async ({request}: ActionFunctionArgs) => {
     })
   }
 
-  return json({result})
+  return {result}
 }
 
 export const meta: MetaFunction = ({matches}) => {

--- a/app/routes/app.user.tsx
+++ b/app/routes/app.user.tsx
@@ -1,7 +1,6 @@
 import {
   type LoaderFunctionArgs,
   type MetaFunction,
-  json,
   type ActionFunction
 } from '@remix-run/node'
 import {useLoaderData, Outlet, useActionData} from '@remix-run/react'
@@ -18,6 +17,7 @@ import {getPrisma} from '~/lib/prisma.server'
 import {hashPassword} from '~/lib/user.server'
 import {FlashMessage} from '~/lib/components/flash'
 import {formatAsDateTime} from '~/lib/utils/format'
+import {reviveDate} from '~/lib/utils/serialize'
 
 export const loader = async ({request}: LoaderFunctionArgs) => {
   const sessionUser = await ensureUser(request, 'user:self', {})
@@ -31,7 +31,7 @@ export const loader = async ({request}: LoaderFunctionArgs) => {
     orderBy: {updatedAt: 'desc'}
   })
 
-  return json({user, sessions, currentSession: sessionUser.sessionId})
+  return {user, sessions, currentSession: sessionUser.sessionId}
 }
 
 export const meta: MetaFunction = ({matches}) => {
@@ -66,14 +66,14 @@ export const action: ActionFunction = async ({request}) => {
         data: {passwordHash: hashedPassword}
       })
     } else {
-      return json({
+      return {
         message: 'New password and confirmation did not match',
         type: 'bg-danger'
-      })
+      }
     }
   }
 
-  return json({message: 'Account updated', type: 'bg-success'})
+  return {message: 'Account updated', type: 'bg-success'}
 }
 
 const User = () => {
@@ -161,7 +161,7 @@ const User = () => {
                   )}
                   <br />
                   <span className="text-sm text-gray-400">
-                    {formatAsDateTime(updatedAt)}
+                    {formatAsDateTime(reviveDate(updatedAt).toISOString())}
                   </span>
                 </div>
               )

--- a/app/routes/app_.login.tsx
+++ b/app/routes/app_.login.tsx
@@ -2,7 +2,7 @@ import {
   type ActionFunctionArgs,
   type MetaFunction,
   type HeadersArgs,
-  json,
+  data,
   redirect
 } from '@remix-run/node'
 import {useActionData} from '@remix-run/react'
@@ -48,7 +48,7 @@ export const action = async ({request}: ActionFunctionArgs) => {
   )
 
   if (!user) {
-    return json(
+    return data(
       {
         error: 'User not found.',
         twoFactor: false,
@@ -60,7 +60,7 @@ export const action = async ({request}: ActionFunctionArgs) => {
   }
 
   if (!(await checkPassword(password, user.passwordHash))) {
-    return json(
+    return data(
       {
         error: 'Pasword does not match.',
         twoFactor: false,
@@ -72,7 +72,7 @@ export const action = async ({request}: ActionFunctionArgs) => {
   }
 
   if (user.totpSecret !== '' && otp === null) {
-    return json(
+    return data(
       {twoFactor: true, error: false, email, password},
       {headers: headers()}
     )
@@ -90,7 +90,7 @@ export const action = async ({request}: ActionFunctionArgs) => {
     const result = (await verifyTOTP(opts)) !== null
 
     if (!result) {
-      return json(
+      return data(
         {
           twoFactor: true,
           error: '2FA verification failed.',

--- a/tests/unit-utils.ts
+++ b/tests/unit-utils.ts
@@ -57,7 +57,7 @@ export const userForTest = async ({
       return headers
     }
 
-    const response = await logonAction({
+    const response = (await logonAction({
       request: appRequest('/logon', {
         method: 'POST',
         headers: {'Content-Type': 'application/x-www-form-urlencoded'},
@@ -65,7 +65,7 @@ export const userForTest = async ({
       }),
       context: {},
       params: {}
-    })
+    })) as Awaited<ReturnType<typeof logonAction>> & {headers: Headers}
 
     sessionCookie = response.headers.getSetCookie()[0]
 

--- a/tests/unit/documents.spec.ts
+++ b/tests/unit/documents.spec.ts
@@ -85,17 +85,13 @@ describe('Documents', () => {
 
     const newId = addResponse.headers.get('Location')!.split('/')[3]
 
-    const adminListLoaderResponse = await listLoader({
+    const adminListLoaderData = await listLoader({
       request: appRequest('/app/documents', {
         headers: await admin.sessionHeader()
       }),
       context: {},
       params: {}
     })
-
-    expect(adminListLoaderResponse.status).toBe(200)
-
-    const adminListLoaderData = await adminListLoaderResponse.json()
 
     const adminCanSeeDocument = adminListLoaderData.documents.reduce(
       (check, value) => {
@@ -108,17 +104,13 @@ describe('Documents', () => {
 
     expect(adminCanSeeDocument).toBeTruthy()
 
-    const readerListLoaderResponse = await listLoader({
+    const readerListLoaderData = await listLoader({
       request: appRequest('/app/documents', {
         headers: await reader.sessionHeader()
       }),
       context: {},
       params: {}
     })
-
-    expect(readerListLoaderResponse.status).toBe(200)
-
-    const readerListLoaderData = await readerListLoaderResponse.json()
 
     const readerCanSeeDocument = readerListLoaderData.documents.reduce(
       (check, value) => {
@@ -139,7 +131,7 @@ describe('Documents', () => {
       params: {document: newId}
     })
 
-    expect(adminViewRequest.status).toBe(200)
+    expect(adminViewRequest).not.toBeUndefined()
 
     await expect(async () => {
       await readLoader({

--- a/tests/unit/logon-flow.spec.ts
+++ b/tests/unit/logon-flow.spec.ts
@@ -25,7 +25,7 @@ describe('Logon Flow', () => {
   test('Logon page should return a session and that session should return the new user', async () => {
     const {user, password, dispose} = await userForTest({role: 'admin'})
 
-    const response = await logonAction({
+    const response = (await logonAction({
       request: appRequest('/logon', {
         method: 'POST',
         headers: {'Content-Type': 'application/x-www-form-urlencoded'},
@@ -33,7 +33,7 @@ describe('Logon Flow', () => {
       }),
       context: {},
       params: {}
-    })
+    })) as Awaited<ReturnType<typeof logonAction>> & {headers: Headers}
 
     expect(response.headers.getSetCookie()[0]).toMatch(/^__session=.*?;/)
 

--- a/tests/unit/passwords.spec.ts
+++ b/tests/unit/passwords.spec.ts
@@ -91,15 +91,13 @@ describe('Passwords', () => {
 
     const newId = addResponse.headers.get('Location')!.split('/')[3]
 
-    const adminListLoaderResponse = await listLoader({
+    const adminListLoaderData = await listLoader({
       request: appRequest('/app/passwords', {
         headers: await admin.sessionHeader()
       }),
       context: {},
       params: {}
     })
-
-    const adminListLoaderData = await adminListLoaderResponse.json()
 
     const adminCanSeePassword = adminListLoaderData.passwords.reduce(
       (check, value) => {
@@ -112,17 +110,13 @@ describe('Passwords', () => {
 
     expect(adminCanSeePassword).toBeTruthy()
 
-    const readerListLoaderResponse = await listLoader({
+    const readerListLoaderData = await listLoader({
       request: appRequest('/app/passwords', {
         headers: await reader.sessionHeader()
       }),
       context: {},
       params: {}
     })
-
-    expect(readerListLoaderResponse.status).toBe(200)
-
-    const readerListLoaderData = await readerListLoaderResponse.json()
 
     const readerCanSeePassword = readerListLoaderData.passwords.reduce(
       (check, value) => {
@@ -143,7 +137,7 @@ describe('Passwords', () => {
       params: {password: newId}
     })
 
-    expect(adminViewRequest.status).toBe(200)
+    expect(adminViewRequest).not.toBeUndefined()
 
     await expect(async () => {
       await readLoader({

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,14 +3,25 @@ import {installGlobals} from '@remix-run/node'
 import {defineConfig} from 'vite'
 import tsconfigPaths from 'vite-tsconfig-paths'
 
-installGlobals()
-
 export default defineConfig({
   plugins: [
     remix({
-      ignoredRouteFiles: ['**/*.css']
+      ignoredRouteFiles: ['**/*.css'],
+      future: {
+        v3_fetcherPersist: true,
+        v3_lazyRouteDiscovery: true,
+        v3_relativeSplatPath: true,
+        v3_singleFetch: true
+      }
     }),
     tsconfigPaths()
   ],
   optimizeDeps: {exclude: ['@mapbox/node-pre-gyp']}
 })
+
+declare module '@remix-run/server-runtime' {
+  // or cloudflare, deno, etc.
+  interface Future {
+    v3_singleFetch: true
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,8 @@ export default defineConfig({
         v3_fetcherPersist: true,
         v3_lazyRouteDiscovery: true,
         v3_relativeSplatPath: true,
-        v3_singleFetch: true
+        v3_singleFetch: true,
+        v3_throwAbortReason: true
       }
     }),
     tsconfigPaths()


### PR DESCRIPTION
This PR brings in the changes for the v3 flags in Remix.

- [x] [v3_fetcherPersist](https://remix.run/docs/en/2.13.1/start/future-flags#v3_fetcherpersist)
- [x] [v3_relativeSplatPath](https://remix.run/docs/en/2.13.1/start/future-flags#v3_relativesplatpath)
- [x] [v3_throwAbortReason](https://remix.run/docs/en/2.13.1/start/future-flags#v3_throwabortreason)
- [x] [v3_singleFetch](https://remix.run/docs/en/2.13.1/start/future-flags#v3_singlefetch)
- [x] [v3_lazyRouteDiscovery](https://remix.run/docs/en/2.13.1/start/future-flags#v3_lazyroutediscovery)
